### PR TITLE
feat(TurboSilence): add FanMode and fix Min and Max temp

### DIFF
--- a/custom_components/tholz/__init__.py
+++ b/custom_components/tholz/__init__.py
@@ -36,7 +36,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     }
 
     await hass.config_entries.async_forward_entry_setups(
-        entry, ["binary_sensor", "light", "number", "sensor", "switch", "water_heater"]
+        entry,
+        [
+            "binary_sensor",
+            "light",
+            "number",
+            "select",
+            "sensor",
+            "switch",
+            "water_heater",
+        ],
     )
 
     return True

--- a/custom_components/tholz/entities/heating/const.py
+++ b/custom_components/tholz/entities/heating/const.py
@@ -22,3 +22,8 @@ class HEATING_OP_MODE(IntEnum):
     ECONOMICO = 3
     AQUECER = 4
     RESFRIAR = 5
+
+
+class HEATING_FAN_MODE(IntEnum):
+    SILENCIOSO = 0
+    INTELIGENTE = 1

--- a/custom_components/tholz/entities/heating/heating_fan_mode_select.py
+++ b/custom_components/tholz/entities/heating/heating_fan_mode_select.py
@@ -1,0 +1,86 @@
+from homeassistant.components.select import SelectEntity
+
+from ...utils.const import DOMAIN, CONF_NAME_KEY, ENTITIES_SCAN_INTERVAL
+from ...utils.device import get_device_info
+from ...utils.dict import get_in, set_in
+from .const import HEATING_TYPE, HEATING_FAN_MODE
+from .utils import get_heating_type, get_valid_heatings
+
+
+FAN_MODE_THOLZ_TO_HA = {
+    HEATING_FAN_MODE.SILENCIOSO: "Silencioso",
+    HEATING_FAN_MODE.INTELIGENTE: "Inteligente",
+}
+FAN_MODE_HA_TO_THOLZ = {ha: tholz for tholz, ha in FAN_MODE_THOLZ_TO_HA.items()}
+
+
+def get_heating_fan_mode_selects(hass, entry, manager, data):
+    device_info = get_device_info(entry, data)
+    fan_mode_selects = []
+
+    for heating_key, state in get_valid_heatings(data):
+        if get_heating_type(state) != HEATING_TYPE.TROCADOR_CALOR_FAIRLAND:
+            continue
+
+        fan_mode_selects.append(
+            HeatingFanModeSelect(
+                hass,
+                entry,
+                manager,
+                device_info,
+                heating_key,
+                state,
+            )
+        )
+
+    return fan_mode_selects
+
+
+class HeatingFanModeSelect(SelectEntity):
+    def __init__(self, hass, entry, manager, device_info, heating_key, state):
+        self._hass = hass
+        self._entry = entry
+        self._manager = manager
+        self._device_info = device_info
+        self._heating_key = heating_key
+
+        self._state = state
+
+        self._attr_should_poll = True
+        self._attr_scan_interval = ENTITIES_SCAN_INTERVAL
+
+    async def async_update(self):
+        data = await self._manager.get_status()
+        if data:
+            self._state = get_in(data, self._heating_key)
+
+    async def async_select_option(self, option):
+        if option not in FAN_MODE_HA_TO_THOLZ:
+            return
+
+        self._state["fanMode"] = int(FAN_MODE_HA_TO_THOLZ[option])
+        await self._manager.set_status(set_in({}, self._heating_key, self._state))
+
+    @property
+    def options(self):
+        return list(FAN_MODE_THOLZ_TO_HA.values())
+
+    @property
+    def current_option(self):
+        return FAN_MODE_THOLZ_TO_HA.get(self._state.get("fanMode"))
+
+    @property
+    def name(self):
+        return f"{self._entry.data.get(CONF_NAME_KEY)} Modo Ventilador"
+
+    @property
+    def icon(self):
+        return "mdi:fan"
+
+    @property
+    def unique_id(self):
+        return f"{DOMAIN}_{self._entry.entry_id}_heating_{self._heating_key[-1]}_fan_mode_select"
+
+    @property
+    def device_info(self):
+        return self._device_info

--- a/custom_components/tholz/entities/heating/heating_water_heater.py
+++ b/custom_components/tholz/entities/heating/heating_water_heater.py
@@ -61,6 +61,8 @@ HEATING_WATER_HEATER_CONFIG = {
         "sensor_key": "t3",
         "name": "Piscina",
         "icon": "mdi:pool-thermometer",
+        "min_temp": 18.0,
+        "max_temp": 40.0,
         "tholz_to_ha_opmode": {
             HEATING_OP_MODE.DESLIGADO: STATE_OFF,
             HEATING_OP_MODE.AQUECER: STATE_HEAT_PUMP,
@@ -175,13 +177,23 @@ class HeatingWaterHeater(WaterHeaterEntity):
 
     @property
     def min_temp(self):
+        config = get_heating_water_heater_config(self._state)
         min_sp = self._state.get("minSp")
-        return min_sp / 10 if min_sp is not None else 40.0
+        if min_sp is not None:
+            return min_sp / 10
+        if config.get("min_temp") is not None:
+            return config["min_temp"]
+        return 40.0
 
     @property
     def max_temp(self):
+        config = get_heating_water_heater_config(self._state)
         max_sp = self._state.get("maxSp")
-        return max_sp / 10 if max_sp is not None else 70.0
+        if max_sp is not None:
+            return max_sp / 10
+        if config.get("max_temp") is not None:
+            return config["max_temp"]
+        return 70.0
 
     @property
     def current_operation(self):

--- a/custom_components/tholz/select.py
+++ b/custom_components/tholz/select.py
@@ -1,0 +1,15 @@
+from .entities.heating.heating_fan_mode_select import get_heating_fan_mode_selects
+from .utils.const import DOMAIN
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    manager = hass.data[DOMAIN][entry.entry_id]["manager"]
+    data = await manager.get_status()
+    if not data:
+        return
+
+    entities = [
+        *get_heating_fan_mode_selects(hass, entry, manager, data),
+    ]
+
+    async_add_entities(entities, update_before_add=True)


### PR DESCRIPTION
Meu Trocador de Calor tem "Modo do ventilador", isso é configurável via "fanMode".  Também não vêm `minSp` ou `maxSp` no heating block, e, para piscina não faz sentido começar em 40ºC e o max ser 70ºC. No próprio App o mínimo é 18 e o max é 40, deixei os mesmos valores.

```json
{
  "command": "getDevice",
  "response": {
    "id": REDACTED,
    "reset": 1,
    "firmware": "REDACTED",
    "timezone": -10800,
    "error": 0,
    "heatings": {
      "heat0": {
        "on": false,
        "onAut": false,
        "opMode": 0,
        "fanMode": 1,
        "step": 10,
        "type": 7,
        "t1": 290,
        "t2": 190,
        "t3": 180,
        "sp": 320
      }
    }
  }
}
```