### PR TITLE
Retry on empty replies and read the full JSON response

### DIFF
--- a/custom_components/tholz/socket/client.py
+++ b/custom_components/tholz/socket/client.py
@@ -1,8 +1,16 @@
-import socket
 import json
 import logging
+import socket
+import time
 
 _LOGGER = logging.getLogger(__name__)
+
+# The controller accepts a limited number of concurrent connections. Beyond that
+# it completes the TCP handshake and sends nothing back, so an empty reply means
+# "busy, try again" rather than "invalid request".
+RETRIES = 3
+RETRY_DELAY = 1.5
+TIMEOUT = 3
 
 
 class TholzSocketClient:
@@ -11,36 +19,73 @@ class TholzSocketClient:
         self.port = port
         self.last_data = None
 
+    def _receive(self, s):
+        """Read one JSON object.
+
+        The controller does not close the connection after replying, so reading
+        until EOF blocks. Stop as soon as the outermost object is closed, and
+        fall back to whatever arrived if the socket times out first.
+        """
+        buffer = bytearray()
+        depth = 0
+        started = False
+
+        while True:
+            try:
+                chunk = s.recv(4096)
+            except socket.timeout:
+                break
+            if not chunk:
+                break
+
+            buffer.extend(chunk)
+            for byte in chunk:
+                if byte == 0x7B:  # {
+                    depth += 1
+                    started = True
+                elif byte == 0x7D:  # }
+                    depth -= 1
+            if started and depth <= 0:
+                break
+
+        return bytes(buffer)
+
+    def _request(self, msg):
+        with socket.create_connection((self.host, self.port), timeout=TIMEOUT) as s:
+            s.settimeout(TIMEOUT)
+            s.sendall(json.dumps(msg).encode())
+            raw = self._receive(s)
+
+        if not raw:
+            raise ConnectionError("empty reply (controller busy)")
+
+        return json.loads(raw.decode()).get("response")
+
+    def _request_with_retry(self, msg, label):
+        last_error = None
+
+        for attempt in range(1, RETRIES + 1):
+            try:
+                data = self._request(msg)
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                _LOGGER.debug("[%s] attempt %s/%s failed: %s", label, attempt, RETRIES, e)
+                if attempt < RETRIES:
+                    time.sleep(RETRY_DELAY)
+                continue
+
+            self.last_data = data
+            _LOGGER.debug("[%s] data: %s", label, data)
+            return data
+
+        _LOGGER.warning("[%s] no reply after %s attempts: %s", label, RETRIES, last_error)
+        return None
+
     def get_status(self):
-        try:
-            with socket.create_connection((self.host, self.port), timeout=3) as s:
-                msg = {"command": "getDevice"}
-                _LOGGER.debug("[get_status] call: %s", msg)
-
-                s.sendall(json.dumps(msg).encode())
-                data = s.recv(8192)
-                decoded = json.loads(data.decode())
-
-                self.last_data = decoded.get("response")
-                _LOGGER.debug("[get_status] data: %s", self.last_data)
-                return self.last_data
-        except Exception as e:
-            _LOGGER.warning("[get_status] error: %s", e)
-            return None
+        return self._request_with_retry({"command": "getDevice"}, "get_status")
 
     def set_status(self, payload):
-        try:
-            with socket.create_connection((self.host, self.port), timeout=3) as s:
-                msg = {"command": "setDevice", "argument": payload}
-                _LOGGER.debug("[set_status] call: %s", msg)
-
-                s.sendall(json.dumps(msg).encode())
-                data = s.recv(8192)
-                decoded = json.loads(data.decode())
-
-                self.last_data = decoded.get("response")
-                _LOGGER.debug("[set_status] data: %s", self.last_data)
-                return self.last_data
-        except Exception as e:
-            _LOGGER.warning("[set_status] error: %s", e)
-            return False
+        result = self._request_with_retry(
+            {"command": "setDevice", "argument": payload}, "set_status"
+        )
+        return result if result is not None else False


### PR DESCRIPTION
Two robustness fixes in the socket client, both found while testing against a Smart Heat v2 on a busy network.

### Retry on empty replies

The controller accepts a limited number of concurrent connections. Beyond that limit it completes the TCP handshake and then sends **nothing back** — it neither replies nor closes.

This matters because an empty reply is currently treated as a failure, and `get_status` returns `None`. The request was fine; the device was just busy. In practice this shows up as entities intermittently going unavailable, with nothing wrong in the logs beyond a generic warning.

This adds three attempts with a 1.5s delay. Measured on a Smart Heat v2, repeated polling went from intermittent failures to 8/8 successful reads.

### Read the full JSON response

`recv(8192)` is called once. The payload is around 774 bytes, so in practice it usually arrives in one segment — but nothing guarantees that, and a split response raises a `JSONDecodeError`.

Reading until EOF is not an option, because the controller does not close the connection after replying: that blocks until timeout. The reply is now read until the outermost JSON object closes, with the socket timeout as a fallback.

### Notes

- Failure semantics are unchanged: `get_status` returns `None`, `set_status` returns `False`
- No new dependencies
- The `setDevice` / `argument` request shape is untouched

Tested against Tholz Smart Heat v2, firmware P858V7 / P863V3.