### PR TITLE
Fail setup cleanly when unreachable, and stop polling on unload

### DIFF
--- a/custom_components/tholz/__init__.py
+++ b/custom_components/tholz/__init__.py
@@ -1,5 +1,6 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .socket.client import TholzSocketClient
 from .socket.client_manager import TholzSocketClientManager
@@ -11,6 +12,17 @@ from .utils.const import (
     CONF_POLLING_INTERVAL_KEY,
     CONF_POLLING_INTERVAL_DEFAULT_VALUE,
 )
+
+
+PLATFORMS = [
+    "binary_sensor",
+    "light",
+    "number",
+    "select",
+    "sensor",
+    "switch",
+    "water_heater",
+]
 
 
 async def async_setup(_hass, _config):
@@ -26,6 +38,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     client = TholzSocketClient(host, port)
     manager = TholzSocketClientManager(client, polling_interval)
+
+    # Fail the setup here instead of forwarding the platforms with no data.
+    # Entity setup assumes a populated payload, so an unreachable controller
+    # would otherwise raise while the config flow is still running.
+    if await manager.get_status() is None:
+        raise ConfigEntryNotReady(f"no reply from the controller at {host}:{port}")
+
     manager.start(hass)
 
     if DOMAIN not in hass.data:
@@ -35,17 +54,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         "manager": manager,
     }
 
-    await hass.config_entries.async_forward_entry_setups(
-        entry,
-        [
-            "binary_sensor",
-            "light",
-            "number",
-            "select",
-            "sensor",
-            "switch",
-            "water_heater",
-        ],
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unloaded:
+        stored = hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+        if stored:
+            await stored["manager"].stop()
+
+    return unloaded

--- a/custom_components/tholz/socket/client_manager.py
+++ b/custom_components/tholz/socket/client_manager.py
@@ -1,7 +1,10 @@
 import asyncio
+import logging
 from datetime import datetime
 
 from .client import TholzSocketClient
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class TholzSocketClientManager:
@@ -17,14 +20,40 @@ class TholzSocketClientManager:
         if self._task is None:
             self._task = hass.loop.create_task(self._updater())
 
+    async def stop(self):
+        """Cancel the polling task.
+
+        Without this the task outlives the config entry, so reloading or
+        removing the integration leaves an extra poller running against the
+        controller for the lifetime of the process.
+        """
+        if self._task is None:
+            return
+
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._task = None
+
     async def _fetch_data(self):
         self._data = await asyncio.to_thread(self._client.get_status)
         self._last_update = datetime.now()
 
     async def _updater(self):
         while True:
-            async with self._lock:
-                await self._fetch_data()
+            try:
+                async with self._lock:
+                    await self._fetch_data()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                # Keep polling. An unhandled error here would end the task and
+                # silently stop every update until Home Assistant restarts.
+                _LOGGER.exception("unexpected error while polling the controller")
+
             await asyncio.sleep(self._polling_interval)
 
     async def get_status(self):


### PR DESCRIPTION
Three lifecycle issues in `__init__.py` / `client_manager.py`. Independent of #80, though they compound with it.

### Setup does not check the first read — likely cause of #34

`async_setup_entry` starts the poller and immediately forwards the platforms. It never checks whether the first read succeeded.

Entity setup assumes a populated payload (`get_valid_heatings(data)` and friends), so when the controller is unreachable — or simply busy, since it accepts a limited number of connections — `data` is `None` and entity setup raises while the config flow is still running. The user sees:

> Não foi possível carregar o fluxo de configuração: 500 Internal Server Error

which matches #34 exactly, and gives no hint that the cause is the device not answering.

Raising `ConfigEntryNotReady` instead lets Home Assistant retry with backoff and shows the entry as waiting for the device, which is the expected behaviour for a network device that is temporarily unreachable.

### No `async_unload_entry`

`manager.start()` creates a polling task that is never cancelled, because the integration has no unload handler. Reloading the integration leaves the previous poller running, and each reload adds another one — all competing for the small number of connections the controller accepts.

This adds `async_unload_entry` and a `stop()` on the manager that cancels the task.

### The polling loop dies on any unexpected error

`_updater` has no error handling around `_fetch_data`. Any unexpected exception ends the task, and every update stops silently until Home Assistant is restarted — with no entity going unavailable to signal it.

It now logs and keeps polling, while still propagating `CancelledError` so `stop()` works.

### Notes

- The platform list moved to a module-level `PLATFORMS` constant, since unload needs the same list
- No behaviour change when the controller is reachable

Tested against Tholz Smart Heat v2, firmware P858V7 / P863V3.