### PR TITLE
Fix the options flow, broken on current Home Assistant

### DIFF
--- a/custom_components/tholz/config_flow.py
+++ b/custom_components/tholz/config_flow.py
@@ -39,12 +39,12 @@ class TholzConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     def async_get_options_flow(config_entry):
-        return TholzConfigFlowOptionsFlowHandler(config_entry)
+        return TholzConfigFlowOptionsFlowHandler()
 
 
 class TholzConfigFlowOptionsFlowHandler(config_entries.OptionsFlow):
-    def __init__(self, config_entry):
-        self.config_entry = config_entry
+    # config_entry is provided by Home Assistant and is read-only. Assigning it
+    # here raises AttributeError on current releases.
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:


### PR DESCRIPTION
The options dialog currently returns **500 Internal Server Error** on recent Home Assistant releases, so no option can be changed after the entry is created — host, port and polling interval are all unreachable.

### Cause

`OptionsFlow.config_entry` is now a read-only property populated by Home Assistant. Assigning it in the constructor raises:

```
AttributeError: property 'config_entry' of 'TholzConfigFlowOptionsFlowHandler' object has no setter
```

The traceback comes from `async_get_options_flow` → `__init__`, so the failure happens while the flow is being created, before any step runs. That is why it surfaces as a bare 500 rather than a form error.

### Fix

Drop the constructor — Home Assistant sets `config_entry` itself — and stop forwarding the argument from `async_get_options_flow`.

### Verification

Home Assistant 2026.5.4, Smart Heat v2.

Before: `POST /api/config/config_entries/options/flow` → `500 Internal Server Error`
After: returns the form with `host`, `port` and `polling_interval`.

Worth noting this is independent of #80 and #81 and can go in on its own.